### PR TITLE
add Fileinfo to list of required PHP extensions

### DIFF
--- a/core/quickstart/requirements/index.md
+++ b/core/quickstart/requirements/index.md
@@ -19,6 +19,7 @@ Only if you plan to use Redis and MongoDB for data storage, you might need to do
 
 * CURL
 * DOM
+* Fileinfo
 * GD
 * JSON
 * OpenSSL


### PR DESCRIPTION
on some systems, fileinfo is a separate extension that is not included in the base php package