### PR TITLE
Add missing variable for s3 compatible APIs

### DIFF
--- a/pro/cloudstorage/introduction/index.md
+++ b/pro/cloudstorage/introduction/index.md
@@ -20,6 +20,7 @@ Currently only Amazon S3 and services having a S3 compatible api are supported.
 return [
     'cloudStorage' => [
         'uploads' => [
+            'url' => getenv('S3_URL'), // Set this value if you use a S3 compatible service / api
             'key' => getenv('S3_KEY'),
             'secret' => getenv('S3_SECRET'),
             'region' => 'eu-central-1',


### PR DESCRIPTION
The current state of documentation does not mention the variable to use s3 compatible APIs.